### PR TITLE
Fix for deadlock on expired locks

### DIFF
--- a/score/distlock/_init.py
+++ b/score/distlock/_init.py
@@ -185,9 +185,9 @@ class Lock:
                                   acquired=datetime.now(),
                                   updated=datetime.now(),
                                   token=mktoken())
+        self.conf.vacuum(session)
         session.add(lock)
         try:
-            self.conf.vacuum(session)
             session.flush()
             session.commit()
             self.token = lock.token


### PR DESCRIPTION
- We need to call vacuum() _before_ adding the lock to the session,
  otherwise the session  will always raise an IntegrityError
  when requiring the lock.
